### PR TITLE
_leaflet_id instead of _leafletId

### DIFF
--- a/src/L.Routing.js
+++ b/src/L.Routing.js
@@ -227,11 +227,11 @@ L.Routing = L.Control.extend({
     var prev = marker._routing.prevMarker;
     var next = marker._routing.nextMarker;
 
-    if (this._waypoints._first && marker._leafletId === this._waypoints._first._leafletId) {
+    if (this._waypoints._first && marker._leaflet_id === this._waypoints._first._leaflet_id) {
       this._waypoints._first = next;
     }
 
-    if (this._waypoints._last && marker._leafletId === this._waypoints._last._leafletId) {
+    if (this._waypoints._last && marker._leaflet_id === this._waypoints._last._leaflet_id) {
       this._waypoints._last = prev;
     }
 


### PR DESCRIPTION
removeWaypoint is referencing `_leafletId` as Marker/Layer ID, but Leaflet is using `_leaflet_id` (with underscore), see [Util.js (stable)](https://github.com/Leaflet/Leaflet/blob/stable/src/core/Util.js#L30).

This lead to getFirst returning null when the last waypoint has been deleted and the appending marker to be the previous of a deleted one instead of the last.
