### PR TITLE
recalculate all route segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ routing.routing(true);
 routing.snapping(true);
 ```
 
+### Recalculate the complete route by routing each segment
+```javascript
+routing.routeAllSegments(callback);
+```
+
 ### Get first waypoint
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ routing.snapping(true);
 
 ### Recalculate the complete route by routing each segment
 ```javascript
-routing.routeAllSegments(callback);
+routing.rerouteAllSegments(callback);
 ```
 
 ### Get first waypoint

--- a/src/L.Routing.js
+++ b/src/L.Routing.js
@@ -296,6 +296,43 @@ L.Routing = L.Control.extend({
   }
 
   /**
+   * Recalculate the complete route by routing each segment
+   *
+   * @access public
+   *
+   * @param <Function> cb - callback function
+   *
+   * @return void
+   *
+   * @todo add propper error checking for callback
+  */
+  ,routeAllSegments: function(cb) {
+    var numSegments = this.getWaypoints().length - 1;
+    var callbackCount = 0;
+    var $this = this;
+
+    var callback = function(err, data) {
+      callbackCount++;
+      if (callbackCount >= numSegments) {
+        $this.fire('routing:routeAllSegmentsEnd');
+        if (cb) {
+          cb(err);
+        }
+      }
+    };
+
+    $this.fire('routing:routeAllSegmentsStart');
+
+    if (numSegments < 1) {
+      return callback(null, true);
+    }
+
+    this._eachSegment(function(m1, m2) {
+      this._routeSegment(m1, m2, callback);
+    });
+  }
+
+  /**
    * Route segment between two markers
    *
    * @access private

--- a/src/L.Routing.js
+++ b/src/L.Routing.js
@@ -306,7 +306,7 @@ L.Routing = L.Control.extend({
    *
    * @todo add propper error checking for callback
   */
-  ,routeAllSegments: function(cb) {
+  ,rerouteAllSegments: function(cb) {
     var numSegments = this.getWaypoints().length - 1;
     var callbackCount = 0;
     var $this = this;
@@ -314,14 +314,14 @@ L.Routing = L.Control.extend({
     var callback = function(err, data) {
       callbackCount++;
       if (callbackCount >= numSegments) {
-        $this.fire('routing:routeAllSegmentsEnd');
+        $this.fire('routing:rerouteAllSegmentsEnd');
         if (cb) {
           cb(err);
         }
       }
     };
 
-    $this.fire('routing:routeAllSegmentsStart');
+    $this.fire('routing:rerouteAllSegmentsStart');
 
     if (numSegments < 1) {
       return callback(null, true);


### PR DESCRIPTION
Adds a public method routeAllSegments to recalculate the complete route by routing each segment.

Use-case is to update the route after routing options like profile (mode of transport) have been changed by the user.

Another way to update the route would be to send a single request with all waypoints and split the result into segments. Probably depends on what the routing engine supports. Leaving that as a task for later.
